### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Use a Behringer X-Touch Mini MIDI controller to remote control a Behringer X-Air
 You need Python 3.5 or later. Please make sure to install required libraries:
 
 	$ sudo pip3 install -r requirements.txt
+  
+On modern debian systems you might have to create a virtual python environment first (or pass --break-system-packages to pip)  
 
 ## Update
 


### PR DESCRIPTION
Updates Readme for modern debian systems
On modern debian systems, python packages are managed externally via apt. Installing the requirements using the provided command therefore fails; using a venv is best practice but —break-system-packages might work, too.